### PR TITLE
Use latest oj version with time format set to xmlschema

### DIFF
--- a/lenjador.gemspec
+++ b/lenjador.gemspec
@@ -5,7 +5,7 @@ $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
 Gem::Specification.new do |gem|
   gem.name          = RUBY_PLATFORM =~ /java/ ? 'lenjador-jruby' : 'lenjador'
-  gem.version       = '1.3.0'
+  gem.version       = '1.4.0'
   gem.authors       = ['Salemove']
   gem.email         = ['support@salemove.com']
   gem.description   = "It's lenjadoric"

--- a/lenjador.gemspec
+++ b/lenjador.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |gem|
   if RUBY_PLATFORM =~ /java/
     gem.add_dependency 'jrjackson'
   else
-    gem.add_dependency 'oj'
+    gem.add_dependency 'oj', '~> 3.6'
     gem.add_development_dependency 'ruby-prof'
   end
 

--- a/lib/lenjador/utils.rb
+++ b/lib/lenjador/utils.rb
@@ -38,26 +38,10 @@ class Lenjador
 
     def self.overwritable_params
       {
-        :@timestamp => Time.now.utc.iso8601(DECIMAL_FRACTION_OF_SECOND)
+        :@timestamp => Time.now
       }
     end
     private_class_method :overwritable_params
-
-    def self.serialize_time_objects!(object)
-      if object.is_a?(Hash)
-        object.each do |key, value|
-          object[key] = serialize_time_objects!(value)
-        end
-      elsif object.is_a?(Array)
-        object.each_index do |index|
-          object[index] = serialize_time_objects!(object[index])
-        end
-      elsif object.is_a?(Time) || object.is_a?(Date)
-        object.iso8601
-      else
-        object
-      end
-    end
 
     if RUBY_PLATFORM =~ /java/
       require 'jrjackson'
@@ -72,11 +56,13 @@ class Lenjador
       end
     else
       require 'oj'
-      DUMP_OPTIONS = {mode: :compat, time_format: :ruby}.freeze
+      DUMP_OPTIONS = {
+        mode: :custom,
+        time_format: :xmlschema,
+        second_precision: 3
+      }.freeze
 
       def self.generate_json(obj)
-        serialize_time_objects!(obj)
-
         Oj.dump(obj, DUMP_OPTIONS)
       end
     end

--- a/spec/lenjador/utils_spec.rb
+++ b/spec/lenjador/utils_spec.rb
@@ -25,7 +25,7 @@ describe Lenjador::Utils do
     end
 
     it 'includes timestamp' do
-      expect(event[:@timestamp]).to eq('2015-10-11T23:10:21.123Z')
+      expect(event[:@timestamp]).to eq(now)
     end
 
     context 'when @timestamp provided' do
@@ -89,40 +89,11 @@ describe Lenjador::Utils do
     end
   end
 
-  describe '.serialize_time_objects!' do
-    let(:object) do
-      {
-        time: Time.now,
-        hash: {
-          time: Time.now
-        },
-        array: [
-          Time.now,
-          {
-            time: Time.now
-          }
-        ]
-      }
-    end
-
-    let(:serialized_time) { now.iso8601 }
-
-    it 'recursively serializes time objects to iso8601' do
-      o = object.dup
-      described_class.serialize_time_objects!(o)
-
-      expect(o).to eq(
-        time: serialized_time,
-        hash: {
-          time: serialized_time
-        },
-        array: [
-          serialized_time,
-          {
-            time: serialized_time
-          }
-        ]
-      )
+  describe '.generate_json' do
+    it 'serializes time objects to iso8601' do
+      serialized_time = now.iso8601(3)
+      json = described_class.generate_json(time: now)
+      expect(json).to eq(%({"time":"#{serialized_time}"}))
     end
   end
 end


### PR DESCRIPTION
This produced about 40% performance boost as we're serializing time objects
now directly in Oj.

Oj changelog: https://github.com/ohler55/oj/blob/master/CHANGELOG.md

Oj v2 and v3 have some differences so I locked the version to v3. The
previous version didn't work with ruby 2.5. It does not seem that v2 will
be changed to support it. v3 however supports ruby 2.5 just fine.