### PR TITLE
Simplify lenjador setup

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -36,3 +36,6 @@ Style/SafeNavigation:
 
 Performance/RegexpMatch:
   Enabled: no
+
+Style/SingleLineMethods:
+  Enabled: no

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: ruby
 rvm:
-  - 2.3
   - 2.4
   - 2.5
   - jruby

--- a/lenjador.gemspec
+++ b/lenjador.gemspec
@@ -5,7 +5,7 @@ $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
 Gem::Specification.new do |gem|
   gem.name          = RUBY_PLATFORM =~ /java/ ? 'lenjador-jruby' : 'lenjador'
-  gem.version       = '1.4.0'
+  gem.version       = '2.0.0'
   gem.authors       = ['Salemove']
   gem.email         = ['support@salemove.com']
   gem.description   = "It's lenjadoric"

--- a/lenjador.gemspec
+++ b/lenjador.gemspec
@@ -27,7 +27,7 @@ Gem::Specification.new do |gem|
   end
 
   gem.add_development_dependency 'benchmark-ips'
-  gem.add_development_dependency 'bundler', '~> 1.3'
+  gem.add_development_dependency 'bundler'
   gem.add_development_dependency 'pry'
   gem.add_development_dependency 'rake'
   gem.add_development_dependency 'rspec'

--- a/lib/lenjador/adapters.rb
+++ b/lib/lenjador/adapters.rb
@@ -2,21 +2,16 @@
 
 class Lenjador
   module Adapters
-    LOG_LEVELS = %i[debug info warn error fatal unknown].freeze
-
-    def self.get(type, service_name, arguments)
-      raise "Unsupported logger: #{type}" if type != 'stdout'
-
+    def self.get(service_name, config)
       adapter =
-        if arguments.fetch(:json, false)
+        if config.fetch(:json, false)
           require_relative 'adapters/stdout_json_adapter'
           StdoutJsonAdapter
         else
           require_relative 'adapters/stdout_adapter'
           StdoutAdapter
         end
-      level = LOG_LEVELS.index(arguments.fetch(:level, :debug).to_sym)
-      adapter.new(level, service_name, arguments)
+      adapter.new(service_name)
     end
   end
 end

--- a/lib/lenjador/adapters/stdout_adapter.rb
+++ b/lib/lenjador/adapters/stdout_adapter.rb
@@ -5,15 +5,10 @@ require 'forwardable'
 class Lenjador
   module Adapters
     class StdoutAdapter
-      extend Forwardable
-
       attr_reader :logger
 
-      def_delegators :@logger, :debug?, :info?, :warn?, :error?, :fatal?
-
-      def initialize(level, *)
+      def initialize(_service_name)
         @logger = Logger.new(STDOUT)
-        @logger.level = level
       end
 
       def log(level, metadata = {})
@@ -24,7 +19,7 @@ class Lenjador
           data.empty? ? nil : Utils.generate_json(data)
         ].compact.join(' ')
 
-        @logger.public_send level, log_data
+        @logger.add(level, log_data)
       end
     end
   end

--- a/lib/lenjador/adapters/stdout_json_adapter.rb
+++ b/lib/lenjador/adapters/stdout_json_adapter.rb
@@ -3,45 +3,17 @@
 class Lenjador
   module Adapters
     class StdoutJsonAdapter
-      def initialize(level, service_name, *)
-        @level = level
-        @service_name = service_name
+      def initialize(service_name)
         @application_name = Utils.application_name(service_name)
         @mutex = Mutex.new if RUBY_ENGINE == 'jruby'
       end
 
       def log(level, metadata = {})
-        return unless meets_threshold?(level)
-
-        message = Utils.build_event(metadata, level, @application_name)
+        message = Utils.build_event(metadata, Lenjador::SEV_LABEL[level], @application_name)
         print_line(Utils.generate_json(message))
       end
 
-      def debug?
-        meets_threshold?(:debug)
-      end
-
-      def info?
-        meets_threshold?(:info)
-      end
-
-      def warn?
-        meets_threshold?(:warn)
-      end
-
-      def error?
-        meets_threshold?(:error)
-      end
-
-      def fatal?
-        meets_threshold?(:fatal)
-      end
-
       private
-
-      def meets_threshold?(level)
-        LOG_LEVELS.index(level) >= @level
-      end
 
       # puts is atomic in MRI starting from 2.5.0
       if RUBY_ENGINE == 'ruby' && RUBY_VERSION >= '2.5.0'

--- a/spec/lenjador/adapters/stdout_adapter_spec.rb
+++ b/spec/lenjador/adapters/stdout_adapter_spec.rb
@@ -3,45 +3,45 @@ require 'lenjador/adapters/stdout_adapter'
 
 describe Lenjador::Adapters::StdoutAdapter do
   it 'creates a stdout logger' do
-    io_logger = described_class.new(0)
+    io_logger = described_class.new('service name')
 
-    logger = io_logger.instance_variable_get(:@logger)
+    logger = io_logger.logger
     expect(logger).to be_a Logger
   end
 
   describe '#log' do
-    let(:adapter) { described_class.new(0) }
+    let(:adapter) { described_class.new('sevice name') }
     let(:logger) { adapter.logger }
 
     context 'with only a message' do
       it 'stringifies it correctly' do
-        expect(logger).to receive(:info).with('test')
+        expect(logger).to receive(:add).with(Logger::Severity::INFO, 'test')
 
-        adapter.log :info, message: 'test'
+        adapter.log Lenjador::Severity::INFO, message: 'test'
       end
     end
 
     context 'with an empty message' do
       it 'stringifies it correctly' do
-        expect(logger).to receive(:info).with(' {"a":"b"}')
+        expect(logger).to receive(:add).with(Logger::Severity::INFO, ' {"a":"b"}')
 
-        adapter.log :info, message: '', a: 'b'
+        adapter.log Lenjador::Severity::INFO, message: '', a: 'b'
       end
     end
 
     context 'with no message' do
       it 'stringifies it correctly' do
-        expect(logger).to receive(:info).with('{"a":"b"}')
+        expect(logger).to receive(:add).with(Logger::Severity::INFO, '{"a":"b"}')
 
-        adapter.log :info, a: 'b'
+        adapter.log Lenjador::Severity::INFO, a: 'b'
       end
     end
 
     context 'with a message and metadata' do
       it 'stringifies it correctly' do
-        expect(logger).to receive(:info).with('test {"a":"b"}')
+        expect(logger).to receive(:add).with(Logger::Severity::INFO, 'test {"a":"b"}')
 
-        adapter.log :info, message: 'test', a: 'b'
+        adapter.log Lenjador::Severity::INFO, message: 'test', a: 'b'
       end
     end
   end

--- a/spec/lenjador/adapters/stdout_json_adapter_spec.rb
+++ b/spec/lenjador/adapters/stdout_json_adapter_spec.rb
@@ -3,11 +3,6 @@ require 'json'
 require 'lenjador/adapters/stdout_json_adapter'
 
 describe Lenjador::Adapters::StdoutJsonAdapter do
-  let(:debug_level_code) { 0 }
-  let(:debug_level) { Lenjador::Adapters::LOG_LEVELS[debug_level_code] }
-  let(:info_level_code) { 1 }
-  let(:info_level) { Lenjador::Adapters::LOG_LEVELS[info_level_code] }
-
   let(:stdout) { StringIO.new }
 
   around do |example|
@@ -22,35 +17,24 @@ describe Lenjador::Adapters::StdoutJsonAdapter do
   end
 
   describe '#log' do
-    context 'when below threshold' do
-      let(:adapter) { described_class.new(debug_level_code, service_name) }
-      let(:metadata) { {x: 'y'} }
-      let(:event) { {a: 'b', x: 'y'} }
-      let(:serialized_event) { JSON.dump(event) }
-      let(:service_name) { 'my-service' }
-      let(:application_name) { 'my_service' }
+    let(:adapter) { described_class.new(service_name) }
+    let(:metadata) { {x: 'y'} }
+    let(:event) { {a: 'b', x: 'y'} }
+    let(:serialized_event) { JSON.dump(event) }
+    let(:service_name) { 'my-service' }
+    let(:application_name) { 'my_service' }
+    let(:info) { Lenjador::Severity::INFO }
+    let(:info_label) { 'info' }
 
-      before do
-        allow(Lenjador::Utils).to receive(:build_event)
-          .with(metadata, info_level, application_name)
-          .and_return(event)
-      end
-
-      it 'sends serialized event to $stdout' do
-        adapter.log(info_level, metadata)
-        expect(output).to eq serialized_event + "\n"
-      end
+    before do
+      allow(Lenjador::Utils).to receive(:build_event)
+        .with(metadata, info_label, application_name)
+        .and_return(event)
     end
 
-    context 'when above threshold' do
-      let(:adapter) { described_class.new(info_level_code, service_name) }
-      let(:metadata) { {x: 'y'} }
-      let(:service_name) { 'my-service' }
-
-      it 'does not log the event' do
-        adapter.log(debug_level, metadata)
-        expect(output).to be_empty
-      end
+    it 'sends serialized event to $stdout' do
+      adapter.log(info, metadata)
+      expect(output).to eq serialized_event + "\n"
     end
   end
 

--- a/spec/lenjador_spec.rb
+++ b/spec/lenjador_spec.rb
@@ -3,34 +3,31 @@ require 'spec_helper'
 describe Lenjador do
   describe '.build' do
     it 'creates stdout logger' do
-      expect(described_class).to receive(:new) do |adapters|
-        expect(adapters.count).to be(1)
-        expect(adapters.first).to be_a(described_class::Adapters::StdoutAdapter)
+      expect(described_class).to receive(:new) do |adapter|
+        expect(adapter).to be_a(described_class::Adapters::StdoutAdapter)
       end
 
-      described_class.build('test_service', stdout: nil)
+      described_class.build('test_service', {})
     end
 
     it 'creates stdout json logger' do
-      expect(described_class).to receive(:new) do |adapters|
-        expect(adapters.count).to be(1)
-        expect(adapters.first).to be_a(described_class::Adapters::StdoutJsonAdapter)
+      expect(described_class).to receive(:new) do |adapter|
+        expect(adapter).to be_a(described_class::Adapters::StdoutJsonAdapter)
       end
 
-      described_class.build('test_service', stdout: {json: true})
+      described_class.build('test_service', json: true)
     end
 
     it 'creates stdout logger when no loggers are specified' do
-      expect(described_class).to receive(:new) do |adapters|
-        expect(adapters.count).to be(1)
-        expect(adapters.first).to be_a(described_class::Adapters::StdoutAdapter)
+      expect(described_class).to receive(:new) do |adapter|
+        expect(adapter).to be_a(described_class::Adapters::StdoutAdapter)
       end
 
       described_class.build('test_service', nil)
     end
 
     it 'creates preprocessor when preprocessor defined' do
-      expect(described_class).to receive(:new) do |_adapters, preprocessors|
+      expect(described_class).to receive(:new) do |_adapter, _level, preprocessors|
         expect(preprocessors.count).to be(1)
         expect(preprocessors.first).to be_a(described_class::Preprocessors::Blacklist)
       end
@@ -41,64 +38,66 @@ describe Lenjador do
   end
 
   context 'when preprocessor defined' do
-    let(:lenjador) { described_class.new([adapter], [preprocessor]) }
+    let(:lenjador) { described_class.new(adapter, level, [preprocessor]) }
     let(:adapter) { double }
+    let(:level) { Lenjador::Severity::DEBUG }
     let(:preprocessor) { double }
     let(:data) { {data: 'data'} }
 
     it 'preprocesses data before logging' do
       expect(preprocessor).to receive(:process).with(data).and_return(data.merge(processed: true)).ordered
-      expect(adapter).to receive(:log).with(:info, data.merge(processed: true)).ordered
+      expect(adapter).to receive(:log).with(described_class::Severity::INFO, data.merge(processed: true)).ordered
 
       lenjador.info(data)
     end
   end
 
   context 'when parsing log data' do
-    let(:lenjador) { described_class.new([adapter], preprocessors) }
+    let(:lenjador) { described_class.new(adapter, level, preprocessors) }
     let(:adapter) { double }
+    let(:level) { Lenjador::Severity::DEBUG }
     let(:preprocessors) { [] }
 
     it 'parses empty string with nil metadata' do
-      expect(adapter).to receive(:log).with(:info, message: '')
+      expect(adapter).to receive(:log).with(described_class::Severity::INFO, message: '')
 
       lenjador.info('', nil)
     end
 
     it 'parses nil as metadata' do
-      expect(adapter).to receive(:log).with(:info, message: nil)
+      expect(adapter).to receive(:log).with(described_class::Severity::INFO, message: nil)
 
       lenjador.info(nil)
     end
 
     it 'parses only message' do
-      expect(adapter).to receive(:log).with(:info, message: 'test message')
+      expect(adapter).to receive(:log).with(described_class::Severity::INFO, message: 'test message')
 
       lenjador.info 'test message'
     end
 
     it 'parses only metadata' do
-      expect(adapter).to receive(:log).with(:info, test: 'data')
+      expect(adapter).to receive(:log).with(described_class::Severity::INFO, test: 'data')
 
       lenjador.info test: 'data'
     end
 
     it 'parses message and metadata' do
-      expect(adapter).to receive(:log).with(:info, message: 'test message', test: 'data')
+      expect(adapter).to receive(:log).with(described_class::Severity::INFO, message: 'test message', test: 'data')
 
       lenjador.info 'test message', test: 'data'
     end
 
     it 'parses block as a message' do
       message = 'test message'
-      expect(adapter).to receive(:log).with(:info, message: message)
+      expect(adapter).to receive(:log).with(described_class::Severity::INFO, message: message)
 
       lenjador.info { message }
     end
 
     it 'ignores progname on block syntax' do
       message = 'test message'
-      expect(adapter).to receive(:log).with(:info, message: message)
+      expect(adapter).to receive(:log).with(described_class::Severity::INFO, message: message)
 
       lenjador.info('progname') { message }
     end
@@ -106,9 +105,7 @@ describe Lenjador do
 
   context 'with log level' do
     context 'when adapter has debug level' do
-      let(:logger) do
-        described_class.build('test_service', stdout: {level: 'debug'})
-      end
+      let(:logger) { described_class.build('test_service', level: 'debug') }
 
       it 'responds true to debug? and higher levels' do
         expect(logger.debug?).to be(true)
@@ -120,9 +117,7 @@ describe Lenjador do
     end
 
     context 'when adapter has info level' do
-      let(:logger) do
-        described_class.build('test_service', stdout: {level: 'info'})
-      end
+      let(:logger) { described_class.build('test_service', level: 'info') }
 
       it 'responds true to info? and higher levels' do
         expect(logger.debug?).to be(false)


### PR DESCRIPTION
1. Lenjador does not take multiple adapters as a config any more. This
   was never used and just makes the logger logic more complex. Instead
   of passing `{stdout: {json: true}}` you should now pass `{json: true}`
2. We now don't preprocess log messages when the severity does not
   match. This should give a nice performance boost in cases when logger
   level is set to info but there are a lot of debug messages.