### PR TITLE
Add support for OpenTelemetry

### DIFF
--- a/lenjador.gemspec
+++ b/lenjador.gemspec
@@ -5,7 +5,7 @@ $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
 Gem::Specification.new do |gem|
   gem.name          = 'lenjador'
-  gem.version       = '2.1.0'
+  gem.version       = '2.2.0'
   gem.authors       = ['Salemove']
   gem.email         = ['support@salemove.com']
   gem.description   = "It's lenjadoric"

--- a/lenjador.gemspec
+++ b/lenjador.gemspec
@@ -23,6 +23,7 @@ Gem::Specification.new do |gem|
 
   gem.add_development_dependency 'benchmark-ips'
   gem.add_development_dependency 'bundler'
+  gem.add_development_dependency 'opentelemetry-api'
   gem.add_development_dependency 'pry'
   gem.add_development_dependency 'rake'
   gem.add_development_dependency 'rspec'

--- a/lib/lenjador/adapters/stdout_json_adapter.rb
+++ b/lib/lenjador/adapters/stdout_json_adapter.rb
@@ -5,7 +5,6 @@ class Lenjador
     class StdoutJsonAdapter
       def initialize(service_name)
         @application_name = Utils.application_name(service_name)
-        @mutex = Mutex.new if RUBY_ENGINE == 'jruby'
       end
 
       def log(level, metadata = {})
@@ -19,10 +18,6 @@ class Lenjador
       if RUBY_ENGINE == 'ruby' && RUBY_VERSION >= '2.5.0'
         def print_line(str)
           $stdout.puts(str)
-        end
-      elsif RUBY_ENGINE == 'jruby'
-        def print_line(str)
-          @mutex.synchronize { $stdout.write("#{str}\n") }
         end
       else
         def print_line(str)


### PR DESCRIPTION
Previously we used trace_id and span_id from OpenTracing. Both OpenTracing
and also OpenCensus have been migrated into OpenTelemetry
(v1.0 released 2021 Feb) which is supported by CNCF. This commit adds 
support for OpenTelemetry.

This allows us to start migrating to OpenTelemetry without tracing 
information in the logs breaking.