### PR TITLE
Add trace_id and span_id to default whitelist

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,25 @@
+name: Ruby
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        ruby-version: ['2.6', '2.7']
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        submodules: true
+    - name: Set up Ruby
+      uses: ruby/setup-ruby@v1
+      with:
+        ruby-version: ${{ matrix.ruby-version }}
+        bundler-cache: true
+    - name: Run lint & tests
+      run: bundle exec rake

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,2 @@
 node_modules/
 npm-debug.log
-Gemfile.lock
-

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -2,7 +2,7 @@ inherit_gem:
   rubocop-salemove: config/default.yml
 
 AllCops:
-  TargetRubyVersion: 2.4
+  TargetRubyVersion: 2.6
 
 Style/FrozenStringLiteralComment:
   Enabled: yes

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,0 @@
-language: ruby
-rvm:
-  - 2.4
-  - 2.5
-  - 2.7

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,0 +1,78 @@
+PATH
+  remote: .
+  specs:
+    lenjador (2.2.1)
+      lru_redux
+      oj (~> 3.6)
+
+GEM
+  remote: https://rubygems.org/
+  specs:
+    ast (2.4.2)
+    benchmark-ips (2.8.4)
+    coderay (1.1.3)
+    diff-lcs (1.4.4)
+    lru_redux (1.1.0)
+    method_source (1.0.0)
+    oj (3.11.5)
+    opentelemetry-api (0.17.0)
+    parallel (1.20.1)
+    parser (3.0.1.1)
+      ast (~> 2.4.1)
+    pry (0.14.1)
+      coderay (~> 1.1)
+      method_source (~> 1.0)
+    rainbow (3.0.0)
+    rake (13.0.3)
+    regexp_parser (2.1.1)
+    rexml (3.2.5)
+    rspec (3.10.0)
+      rspec-core (~> 3.10.0)
+      rspec-expectations (~> 3.10.0)
+      rspec-mocks (~> 3.10.0)
+    rspec-core (3.10.1)
+      rspec-support (~> 3.10.0)
+    rspec-expectations (3.10.1)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.10.0)
+    rspec-mocks (3.10.2)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.10.0)
+    rspec-support (3.10.2)
+    rubocop (0.93.1)
+      parallel (~> 1.10)
+      parser (>= 2.7.1.5)
+      rainbow (>= 2.2.2, < 4.0)
+      regexp_parser (>= 1.8)
+      rexml
+      rubocop-ast (>= 0.6.0)
+      ruby-progressbar (~> 1.7)
+      unicode-display_width (>= 1.4.0, < 2.0)
+    rubocop-ast (1.5.0)
+      parser (>= 3.0.1.1)
+    rubocop-rspec (1.44.1)
+      rubocop (~> 0.87)
+      rubocop-ast (>= 0.7.1)
+    rubocop-salemove (0.0.5)
+      rubocop (~> 0.82)
+      rubocop-rspec (~> 1.15)
+    ruby-prof (1.4.3)
+    ruby-progressbar (1.11.0)
+    unicode-display_width (1.7.0)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  benchmark-ips
+  bundler
+  lenjador!
+  opentelemetry-api
+  pry
+  rake
+  rspec
+  rubocop-salemove
+  ruby-prof
+
+BUNDLED WITH
+   2.1.4

--- a/lenjador.gemspec
+++ b/lenjador.gemspec
@@ -5,7 +5,7 @@ $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
 Gem::Specification.new do |gem|
   gem.name          = 'lenjador'
-  gem.version       = '2.2.0'
+  gem.version       = '2.2.1'
   gem.authors       = ['Salemove']
   gem.email         = ['support@salemove.com']
   gem.description   = "It's lenjadoric"

--- a/lenjador.gemspec
+++ b/lenjador.gemspec
@@ -11,7 +11,7 @@ Gem::Specification.new do |gem|
   gem.description   = "It's lenjadoric"
   gem.summary       = 'What description said'
   gem.license       = 'MIT'
-  gem.required_ruby_version = '>= 2.4'
+  gem.required_ruby_version = '>= 2.6'
 
   gem.files         = `git ls-files`.split($INPUT_RECORD_SEPARATOR)
   gem.executables   = gem.files.grep(%r{^bin/}) { |f| File.basename(f) }

--- a/lib/lenjador/preprocessors/whitelist.rb
+++ b/lib/lenjador/preprocessors/whitelist.rb
@@ -7,7 +7,7 @@ require 'lenjador/preprocessors/strategies/prune'
 class Lenjador
   module Preprocessors
     class Whitelist
-      DEFAULT_WHITELIST = %w[/id /message /correlation_id /queue].freeze
+      DEFAULT_WHITELIST = %w[/id /message /correlation_id /queue /trace_id /span_id].freeze
       MASK_SYMBOL = '*'
       MASKED_VALUE = MASK_SYMBOL * 5
 


### PR DESCRIPTION
There's nothing sensitive there. This way we don't have to manually specify
it and don't have to think about forgetting it.