### PR TITLE
Automatically publish package on version bump

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,22 @@
+name: Publish Gem
+
+on:
+  push:
+    branches:
+      - master
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 2
+
+
+      - name: Release Gem
+        uses: discourse/publish-rubygems-action@b55d7b91b55e61752dc6cbc2972f8e16fe6c1a02
+        env:
+          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
+          RUBYGEMS_API_KEY: ${{secrets.RUBYGEMS_API_KEY}}
+          RELEASE_COMMAND: rake release

--- a/README.md
+++ b/README.md
@@ -119,3 +119,7 @@ Logger output:
 ```
 Received request {password: "********", "info": {"phone": "+12055555555"}, "addresses": [{"host": "example.com","path": "****"}]}
 ```
+
+## Releasing a new version
+
+A new version is created when a change is merged into the master branch that changes the version number in `lenjador.gemspec`. A Github Action will create a tag for the version and push the `.gem` file to [rubygems.org](https://rubygems.org)


### PR DESCRIPTION
Previously the package needed to be manually published by somebody with
permissions. This is a hasstle if the changes were authored by somebody without
permissions. A Github Action will automatically publish a new version and add a
tag when changes are merged to master that increase the version number in
gemspec. If the version in unchanged when changes are merged then the action
fails but does so silently.

See [this PR](https://github.com/salemove/salestation/pull/59) for related discussion.

CHAN-1774