### PR TITLE
Support logger.add

### DIFF
--- a/lib/lenjador.rb
+++ b/lib/lenjador.rb
@@ -28,6 +28,11 @@ class Lenjador
     @preprocessors = preprocessors
   end
 
+  def add(severity, *args, &block)
+    level = SEV_LABEL.index(severity.to_s)
+    log(level, *args, &block)
+  end
+
   def debug(*args, &block)
     log(Severity::DEBUG, *args, &block)
   end

--- a/spec/lenjador_spec.rb
+++ b/spec/lenjador_spec.rb
@@ -37,6 +37,20 @@ describe Lenjador do
     end
   end
 
+  describe '#add' do
+    let(:adapter) { double }
+    let(:lenjador) { described_class.new(adapter, Lenjador::Severity::INFO, []) }
+
+    it 'logs with severity' do
+      expect(adapter).to receive(:log).with(described_class::Severity::INFO, message: 'info-msg').ordered
+      expect(adapter).to receive(:log).with(described_class::Severity::WARN, message: 'warn-msg').ordered
+
+      lenjador.add('debug', 'debug-msg')
+      lenjador.add('info', 'info-msg')
+      lenjador.add('warn', 'warn-msg')
+    end
+  end
+
   context 'when preprocessor defined' do
     let(:lenjador) { described_class.new(adapter, level, [preprocessor]) }
     let(:adapter) { double }


### PR DESCRIPTION
Ruby's logger has a add method that supports severity at the first argument position. Conform to Ruby's logger and provide a similar "add" method. This supports providing a Lenjador logger to external tools that call "#add" on the provided logger.

MSG-816