### PR TITLE
Handle unknown severity levels

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    lenjador (2.3.0)
+    lenjador (2.3.1)
       lru_redux
       oj (~> 3.6)
 

--- a/lenjador.gemspec
+++ b/lenjador.gemspec
@@ -5,7 +5,7 @@ $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
 Gem::Specification.new do |gem|
   gem.name          = 'lenjador'
-  gem.version       = '2.3.0'
+  gem.version       = '2.3.1'
   gem.authors       = ['Salemove']
   gem.email         = ['support@salemove.com']
   gem.description   = "It's lenjadoric"

--- a/lib/lenjador.rb
+++ b/lib/lenjador.rb
@@ -29,8 +29,7 @@ class Lenjador
   end
 
   def add(severity, *args, &block)
-    level = SEV_LABEL.index(severity.to_s)
-    log(level, *args, &block)
+    log(severity, *args, &block)
   end
 
   def debug(*args, &block)

--- a/spec/lenjador_spec.rb
+++ b/spec/lenjador_spec.rb
@@ -42,12 +42,14 @@ describe Lenjador do
     let(:lenjador) { described_class.new(adapter, Lenjador::Severity::INFO, []) }
 
     it 'logs with severity' do
-      expect(adapter).to receive(:log).with(described_class::Severity::INFO, message: 'info-msg').ordered
-      expect(adapter).to receive(:log).with(described_class::Severity::WARN, message: 'warn-msg').ordered
+      expect(adapter).to receive(:log).with(Logger::INFO, message: 'info-msg').ordered
+      expect(adapter).to receive(:log).with(Logger::WARN, message: 'warn-msg').ordered
+      expect(adapter).to receive(:log).with(Logger::UNKNOWN, message: 'unknown-msg').ordered
 
-      lenjador.add('debug', 'debug-msg')
-      lenjador.add('info', 'info-msg')
-      lenjador.add('warn', 'warn-msg')
+      lenjador.add(Logger::DEBUG, 'debug-msg')
+      lenjador.add(Logger::INFO, 'info-msg')
+      lenjador.add(Logger::WARN, 'warn-msg')
+      lenjador.add(Logger::UNKNOWN, 'unknown-msg')
     end
   end
 


### PR DESCRIPTION
Lenjador#add accepts `severity`. Fall back to `info` when the severity
cannot be mapped to a known "level" to not lose messages.

This was motivated by an external tool calling #add with 'any' severity.